### PR TITLE
feat: implement secure IPC, memory locking, and UI scroll improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+blackout_debug.txt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,7 @@ dependencies = [
  "chacha20poly1305",
  "chrono",
  "dirs",
+ "libc",
  "rand",
  "rand_core 0.10.0",
  "serde",
@@ -189,12 +190,14 @@ dependencies = [
  "blackout-core",
  "ctrlc",
  "dirs",
+ "libc",
  "serde",
  "serde_cbor",
  "serde_json",
  "tokio",
  "toml",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "zeroize",
 ]
@@ -970,6 +973,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1062,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -2027,14 +2048,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]

--- a/blackout-core/Cargo.toml
+++ b/blackout-core/Cargo.toml
@@ -14,4 +14,5 @@ rand = "0.8"
 zeroize = "1.5"
 chacha20poly1305 = "0.10.1"
 rand_core = "0.10.0"
+libc = "0.2.184"
 

--- a/blackout-core/src/ipc.rs
+++ b/blackout-core/src/ipc.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum Request {
@@ -28,4 +29,12 @@ pub enum Request {
 pub enum Response {
     Ok(String),
     Error(String),
+}
+
+pub fn get_socket_path() -> PathBuf {
+    let uid = unsafe { libc::geteuid() };
+    let base_dir = std::env::var("XDG_RUNTIME_DIR")
+        .unwrap_or_else(|_| format!("/run/user/{}", uid));
+    
+    PathBuf::from(base_dir).join("blackout.sock")
 }

--- a/blackout-core/src/storage.rs
+++ b/blackout-core/src/storage.rs
@@ -23,8 +23,7 @@ pub struct Wallet {
 
 impl Wallet {
     pub fn init() -> Self {
-        // $XDG_DATA_LOCAL_DIR/blackout/vault.blackout
-        let path = dirs::data_local_dir().unwrap().join("blackout");
+        let path = dirs::home_dir().unwrap().join(".blackout");
         if !path.exists() {
             fs::create_dir_all(&path).expect("Failed to create directory");
         }

--- a/blackout-core/src/storage.rs
+++ b/blackout-core/src/storage.rs
@@ -23,7 +23,8 @@ pub struct Wallet {
 
 impl Wallet {
     pub fn init() -> Self {
-        let path = dirs::home_dir().unwrap().join(".blackout");
+        // $XDG_DATA_LOCAL_DIR/share/blackout
+        let path = dirs::data_local_dir().unwrap_or_else(|| dirs::home_dir().unwrap().join(".local/share")).join("blackout");
         if !path.exists() {
             fs::create_dir_all(&path).expect("Failed to create directory");
         }

--- a/blackout-core/src/storage.rs
+++ b/blackout-core/src/storage.rs
@@ -23,7 +23,8 @@ pub struct Wallet {
 
 impl Wallet {
     pub fn init() -> Self {
-        let path = dirs::home_dir().unwrap().join(".blackout");
+        // $XDG_DATA_LOCAL_DIR/blackout/vault.blackout
+        let path = dirs::data_local_dir().unwrap().join("blackout");
         if !path.exists() {
             fs::create_dir_all(&path).expect("Failed to create directory");
         }

--- a/blackout/src/app.rs
+++ b/blackout/src/app.rs
@@ -3,6 +3,8 @@ use blackout_core::vault::Entry;
 
 use chrono::{DateTime, Local};
 
+use ratatui::widgets::TableState;
+
 pub trait EntryView {
     fn _id(&self) -> &uuid::Uuid;
     fn service(&self) -> &str;
@@ -70,11 +72,14 @@ pub struct App {
     pub input_buffer: String,     // For password input
     pub form_fields: [String; 3], // service, user, password
     pub current_field: usize,
-    pub selected_entry: usize, // Index of selected entry in list
+    pub table_state: TableState,
 }
 
 impl App {
     pub fn new() -> Self {
+        let mut table_state = TableState::default();
+        table_state.select(Some(0));
+
         Self {
             state: AppState::InitialCheck,
             vault_unlocked: false,
@@ -82,9 +87,15 @@ impl App {
             input_buffer: String::new(),
             form_fields: [String::new(), String::new(), String::new()],
             current_field: 0,
-            selected_entry: 0,
             detail_entry: None,
+            table_state,
         }
+    }
+
+    pub fn get_selected_entry(&self) -> Option<&Entry> {
+        self.table_state
+            .selected()
+            .and_then(|i| self.entries.get(i))
     }
 
     pub fn check_vault_status(&mut self) {
@@ -116,7 +127,7 @@ impl App {
         match serde_json::from_str::<Vec<Entry>>(data) {
             Ok(entries) => {
                 self.entries = entries;
-                self.selected_entry = 0;
+                self.table_state.select(Some(0));
             }
             Err(e) => {
                 let debug_info = format!("Parser Error: {}\n\nReceived Data:\n{}", e, data);
@@ -156,16 +167,19 @@ impl App {
 
     pub fn next_entry(&mut self) {
         if !self.entries.is_empty() {
-            self.selected_entry = (self.selected_entry + 1) % self.entries.len();
+            self.table_state.select(Some(
+                (self.table_state.selected().unwrap_or(0) + 1) % self.entries.len(),
+            ));
         }
     }
 
     pub fn prev_entry(&mut self) {
         if !self.entries.is_empty() {
-            if self.selected_entry == 0 {
-                self.selected_entry = self.entries.len() - 1;
+            let current_index = self.table_state.selected().unwrap_or(0);
+            if current_index == 0 {
+                self.table_state.select(Some(self.entries.len() - 1));
             } else {
-                self.selected_entry -= 1;
+                self.table_state.select(Some(current_index - 1));
             }
         }
     }
@@ -201,19 +215,19 @@ impl App {
     pub fn reset_form(&mut self) {
         self.form_fields = [String::new(), String::new(), String::new()];
         self.current_field = 0;
-        self.selected_entry = 0;
+        self.table_state.select(Some(0));
     }
 
     pub fn delete_selected_entry(&mut self) {
-        if let Some(entry) = self.entries.get(self.selected_entry) {
-            let id = entry.id;
-            match crate::send_command(Request::DeleteEntry { uuid: id }) {
+        if let Some(entry) = self.get_selected_entry() {
+            let uuid = entry.id;
+            match crate::send_command(Request::DeleteEntry { uuid: uuid }) {
                 Ok(Response::Ok(_)) => {
                     self.load_entries();
                     self.state = AppState::EntriesList;
                 }
                 Ok(Response::Error(e)) => {
-                    let debug_info = format!("Delete Error: {}\nID:{}", e, id);
+                    let debug_info = format!("Delete Error: {}\nID:{}", e, uuid);
                     let _ = std::fs::write("blackout_debug.txt", debug_info);
                 }
                 Err(_) => {}
@@ -222,18 +236,20 @@ impl App {
     }
 
     pub fn view_selected_entry(&mut self) {
-        let uuid = self.entries[self.selected_entry].id;
-        if let Ok(Response::Ok(data)) = crate::send_command(Request::GetEntryById { uuid }) {
-            if let Ok(entry) = serde_json::from_str::<Entry>(&data) {
-                self.detail_entry = Some(DetailEntryView(entry));
-                self.state = AppState::ViewEntry;
+        if let Some(entry) = self.get_selected_entry() {
+            let uuid = entry.id;
+            if let Ok(Response::Ok(data)) = crate::send_command(Request::GetEntryById { uuid }) {
+                if let Ok(entry) = serde_json::from_str::<Entry>(&data) {
+                    self.detail_entry = Some(DetailEntryView(entry));
+                    self.state = AppState::ViewEntry;
+                }
+            } else {
+                let debug_info = format!(
+                    "View Entry Error: Failed to get entry details for ID: {}",
+                    uuid
+                );
+                let _ = std::fs::write("blackout_debug.txt", debug_info);
             }
-        } else {
-            let debug_info = format!(
-                "View Entry Error: Failed to get entry details for ID: {}",
-                uuid
-            );
-            let _ = std::fs::write("blackout_debug.txt", debug_info);
         }
     }
 }

--- a/blackout/src/main.rs
+++ b/blackout/src/main.rs
@@ -11,8 +11,6 @@ use std::os::unix::net::UnixStream;
 use color_eyre::Result;
 use ratatui::DefaultTerminal;
 
-const SOCKET_PATH: &str = "/tmp/blackout.sock";
-
 fn main() -> Result<()> {
     color_eyre::install()?;
     let mut app = app::App::new();
@@ -25,7 +23,7 @@ fn main() -> Result<()> {
 }
 
 pub fn send_command(req: Request) -> Result<Response> {
-    let mut stream = UnixStream::connect(SOCKET_PATH)?;
+    let mut stream = UnixStream::connect(blackout_core::ipc::get_socket_path())?;
 
     let req_json = serde_json::to_string(&req)? + "\n";
     stream.write_all(req_json.as_bytes())?;

--- a/blackout/src/ui.rs
+++ b/blackout/src/ui.rs
@@ -8,14 +8,15 @@ use ratatui::{
 
 use crate::app::{App, AppState, EntryView, ListEntryView};
 
-pub fn render(frame: &mut Frame, app: &App) {
+pub fn render(frame: &mut Frame, app: &mut App) {
     let vertical = Layout::vertical([
         Constraint::Length(1),
         Constraint::Fill(1),
         Constraint::Length(1),
     ])
     .spacing(1)
-    .margin(3);
+    .horizontal_margin(3)
+    .vertical_margin(1);
     let [top, main, bottom] = frame.area().layout(&vertical);
 
     let title = Line::from_iter([Span::from("Blackout").bold()]);
@@ -66,29 +67,20 @@ fn render_unlock_prompt(frame: &mut Frame, area: Rect, input: &str) {
     frame.render_widget(pass_paragraph, pass_area);
 }
 
-fn render_entries_list(frame: &mut Frame, area: Rect, app: &App) {
+fn render_entries_list(frame: &mut Frame, area: Rect, app: &mut App) {
     let rows: Vec<Row> = app
         .entries
         .iter()
-        .enumerate()
-        .map(|(i, entry)| {
+        .map(|entry| {
             let view = ListEntryView(entry.clone());
-
-            // format updated_at as "YYYY-MM-DD HH:MM:SS"
             let updated_at = view.updated_at().format("%Y-%m-%d %H:%M:%S").to_string();
-
-            let style = if i == app.selected_entry {
-                Style::new().bold()
-            } else {
-                Style::new().bold().fg(Color::Yellow)
-            };
 
             Row::new(vec![
                 Cell::from(view.service().to_string()),
                 Cell::from(view.username().to_string()),
                 Cell::from(updated_at),
             ])
-            .style(style)
+            .style(Style::new()) 
         })
         .collect();
 
@@ -103,9 +95,14 @@ fn render_entries_list(frame: &mut Frame, area: Rect, app: &App) {
     .header(
         Row::new(vec!["Service", "Username/Email", "Last Modified"])
             .style(Style::new().bold().underlined()),
-    );
+    )
 
-    frame.render_widget(table, area);
+    .style(Style::new().bold())
+    .highlight_symbol("|"); 
+
+    // Renderizamos passando o estado da tabela. 
+    // O ratatui vai fazer a matemática do scroll automaticamente!
+    frame.render_stateful_widget(table, area, &mut app.table_state);
 }
 
 fn render_new_entry_form(frame: &mut Frame, area: Rect, app: &App) {

--- a/blackout_debug.txt
+++ b/blackout_debug.txt
@@ -1,2 +1,2 @@
 Add Entry Error: Vault is locked. Please unlock it first.
-Data:1213iuyhg,8s67atdg8,8z76stxcgas
+Data:microsoft.net,scorpions,trash

--- a/blackoutd/Cargo.toml
+++ b/blackoutd/Cargo.toml
@@ -17,3 +17,5 @@ serde_json = "1.0.149"
 zeroize = "1.5"
 argon2 = "0.5.3"
 uuid = "1.23.0"
+libc = "0.2.184"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }

--- a/blackoutd/src/daemon.rs
+++ b/blackoutd/src/daemon.rs
@@ -1,12 +1,14 @@
 // blackout-daemon/src/daemon.rs
 use anyhow::Result;
+use libc;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::net::UnixListener;
 use tokio::sync::RwLock;
 use tokio::time::interval;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use blackout_core::storage::Wallet;
 use blackout_core::vault::Vault;
@@ -27,9 +29,12 @@ pub struct DaemonState {
 pub struct Daemon {
     storage: Arc<Wallet>,
     state: Arc<RwLock<DaemonState>>,
+    socket_path: PathBuf,
+    uid: u32,
 }
 
 impl Daemon {
+
     pub fn new(storage: Arc<Wallet>) -> Self {
         let state = DaemonState {
             vault: None,
@@ -37,26 +42,32 @@ impl Daemon {
             running: true,
             master_password: None,
             last_activity: Instant::now(),
-            auto_lock_timeout: Duration::from_secs(30), // 30 segundos
+            auto_lock_timeout: Duration::from_secs(30),
         };
+
+        let uid = unsafe { libc::geteuid() };
+        let socket_path = blackout_core::ipc::get_socket_path();
 
         Self {
             storage,
             state: Arc::new(RwLock::new(state)),
+            socket_path: socket_path,
+            uid: uid,
         }
     }
 
     /// Starter
-    pub async fn run(&self, socket_path: &str) -> Result<()> {
+    pub async fn run(&self) -> Result<()> {
         info!("Daemon started! Waiting for authentication...");
 
-        let _ = std::fs::remove_file(socket_path); // Clean old socket
-        let listener = UnixListener::bind(socket_path)?;
+        let _ = std::fs::remove_file(&self.socket_path);
 
-        let mut perms = std::fs::metadata(socket_path)?.permissions();
-        use std::os::unix::fs::PermissionsExt;
-        perms.set_mode(0o600); // rw-----
-        std::fs::set_permissions(socket_path, perms)?;
+        let listener = {
+            let old_umask = unsafe { libc::umask(0o077) };
+            let bind_result = UnixListener::bind(&self.socket_path);
+            unsafe { libc::umask(old_umask) };
+            bind_result? 
+        };
 
         let mut check_interval = interval(Duration::from_millis(500));
 
@@ -71,7 +82,19 @@ impl Daemon {
                 }
 
                 Ok((stream, _addr)) = listener.accept() => {
-                    debug!("New connection recived!");
+                    match stream.peer_cred() {
+                        Ok(cred) => {
+                            if cred.uid() != self.uid {
+                                warn!("HACK ATTEMPT: UID {} tentou se conectar, mas o dono é {}. Conexão derrubada.", cred.uid(), &self.uid);
+                                continue;
+                            }
+                            debug!("Conexão aceita do UID {}", cred.uid());
+                        }
+                        Err(e) => {
+                            warn!("Falha ao ler credenciais do socket: {}. Derrubando.", e);
+                            continue;
+                        }
+                    }
 
                     let state_clone = Arc::clone(&self.state);
                     let storage_clone = Arc::clone(&self.storage);
@@ -83,8 +106,8 @@ impl Daemon {
                         let mut buf_reader = BufReader::new(reader);
                         let mut line = String::new();
 
-                        if let Ok(bytes_read) = buf_reader.read_line(&mut line).await
-                            && bytes_read > 0 {
+                        if let Ok(bytes_read) = buf_reader.read_line(&mut line).await {
+                            if bytes_read > 0 {
                                 use blackout_core::ipc::{Request, Response};
 
                                 let response = match serde_json::from_str::<Request>(&line) {
@@ -97,11 +120,14 @@ impl Daemon {
 
                                 let res_json = serde_json::to_string(&response).unwrap() + "\n";
                                 let _ = writer.write_all(res_json.as_bytes()).await;
-                            };
+                            }
+                        };
                     });
                 }
             }
         }
+
+        let _ = std::fs::remove_file(&self.socket_path);
 
         Ok(())
     }

--- a/blackoutd/src/main.rs
+++ b/blackoutd/src/main.rs
@@ -1,6 +1,9 @@
 mod daemon;
 mod handle;
 
+use tracing::{info, warn, error};
+use std::env;
+
 use crate::daemon::Daemon;
 use blackout_core::storage::Wallet;
 
@@ -8,12 +11,37 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
-    let daemon_path = "/tmp/blackout.sock";
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args: Vec<String> = env::args().collect();
+    let use_mlock = args.contains(&"--mlock".to_string());
+
+    if use_mlock {
+        prevent_memory_swapping()
+            .expect("Panic: Cannot lock memory with mlockall. This is critical for security.");
+    } else {
+        warn!("Running without mlock. This may lead to sensitive data being swapped to disk. Use --mlock flag to improve security.");
+    }
 
     let daemon = Daemon::new(Arc::new(Wallet::init()));
 
-    println!("Iniciando o daemon...");
-    println!("Socket path: {}", daemon_path);
+    info!("Iniciando o daemon...");
 
-    daemon.run(daemon_path).await.unwrap();
+    daemon.run().await.unwrap();
+}
+
+fn prevent_memory_swapping() -> std::io::Result<()> {
+    let flags = libc::MCL_CURRENT | libc::MCL_FUTURE;
+    let result = unsafe { libc::mlockall(flags) };
+
+    if result != 0 {
+        let err = std::io::Error::last_os_error();
+        error!("Failed syscall mlockall: {}", err);
+        return Err(err); 
+    }
+
+    info!("mlockall successful: Memory is locked and will not be swapped to disk.");
+    Ok(())
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+# Dirs
+BIN_DIR="$HOME/.local/bin"
+DATA_DIR="$HOME/.local/share/blackout"
+CONFIG_DIR="$HOME/.config/blackout"
+SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Check dependency
+check_prerequisites() {
+    if [ "$EUID" -eq 0 ]; then
+        echo -e "${RED}Error: Don't run this script as root (sudo).${NC}"
+        echo "Blackout is designed to run in the user space for IPC isolation."
+        exit 1
+    fi
+
+    if ! command -v cargo &> /dev/null; then
+        echo -e "${RED}Error: Cargo (Rust) not found in PATH.${NC}"
+        exit 1
+    fi
+}
+
+# Install
+install_blackout() {
+    local USE_MLOCK=""
+    if [[ "$1" == "--mlock" ]]; then
+        USE_MLOCK="--mlock"
+        echo -e "${YELLOW}Flaged --mlock: Daemon will attempt to prevent memory swapping.${NC}"
+    fi
+
+    local branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+    echo -e "${GREEN}Installing Blackout from branch: ${branch}${NC}"
+    
+    # 1. Compilation
+    echo "Compiling binaries in release mode..."
+    if ! cargo build --release; then
+        echo -e "${RED}Failed to compile.${NC}"
+        exit 1
+    fi
+
+    # 2. Making Directories
+    echo "Creating directories and applying restrictive permissions (chmod 700)..."
+    mkdir -p "$BIN_DIR"
+    mkdir -p "$CONFIG_DIR"
+    mkdir -p "$SYSTEMD_USER_DIR"
+    
+    mkdir -p "$DATA_DIR"
+    chmod 700 "$DATA_DIR"
+
+    # 3. Copying Binaries
+    echo "Installing binaries in $BIN_DIR..."
+    cp target/release/blackoutd "$BIN_DIR/"
+    cp target/release/blackout "$BIN_DIR/"
+    chmod +x "$BIN_DIR/blackoutd" "$BIN_DIR/blackout"
+
+    # 4. Touching service file
+    echo "Touching service file..."
+    cat > "$SYSTEMD_USER_DIR/blackout.service" << EOF
+[Unit]
+Description=Blackout Password Manager Daemon
+After=network.target
+
+[Service]
+Type=simple
+Environment="RUST_LOG=info"
+ExecStart=$BIN_DIR/blackoutd $USE_MLOCK
+Restart=on-failure
+RestartSec=5
+
+# Aditional security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=$DATA_DIR
+ReadWritePaths=/run/user/%U
+PrivateNetwork=yes
+LimitMEMLOCK=infinity
+
+[Install]
+WantedBy=default.target
+EOF
+
+    # 5. Ativando o Daemon
+    echo "Configuring systemd..."
+    systemctl --user daemon-reload
+    systemctl --user enable blackout.service
+    systemctl --user start blackout.service
+
+    echo -e "${GREEN}Installation completed successfully!${NC}"
+    echo "The daemon is running in the background. Test with: blackout --help"
+}
+
+# Uninstall
+uninstall_blackout() {
+    local PURGE=false
+    if [[ "$1" == "--purge" ]]; then
+        PURGE=true
+    fi
+
+    echo -e "${YELLOW}Uninstalling...${NC}"
+
+    # 1. Stopping the daemon
+    if systemctl --user is-active --quiet blackout.service; then
+        echo "Stopping the daemon..."
+        systemctl --user stop blackout.service
+        systemctl --user disable blackout.service
+    fi
+
+    # 2. Cleaning
+    echo "Cleaning up..."
+    rm -f "$BIN_DIR/blackoutd"
+    rm -f "$BIN_DIR/blackout"
+    rm -f "$SYSTEMD_USER_DIR/blackout.service"
+    systemctl --user daemon-reload
+
+    echo "Cleaning Cargo cache..."
+    cargo clean
+
+    # 3. Purging data
+    if [ "$PURGE" = true ]; then
+        echo -e "${RED}Purging data...${NC}"
+        rm -rf "$DATA_DIR"
+        rm -rf "$CONFIG_DIR"
+    else
+        echo -e "${YELLOW}The encrypted vault is still in: $DATA_DIR${NC}"
+        echo "To permanently remove your passwords, run: ./setup.sh uninstall --purge"
+    fi
+
+    echo -e "${GREEN}Uninstallation completed successfully.${NC}"
+}
+
+# CLIs
+check_prerequisites
+
+case "$1" in
+    install)
+        install_blackout "$2"
+        ;;
+    uninstall)
+        uninstall_blackout "$2"
+        ;;
+    *)
+        echo "Use: $0 {install|uninstall}"
+        echo ""
+        echo "Install:"
+        echo ""
+        echo -e "  install\t\tinstall blackout to current user."
+	    echo -e "  install --mlock\tinstall blackout to current user. (Using 'mlock' flag)"
+        echo ""
+        echo "Uninstall:"
+        echo -e "  uninstall\t\tRemove binaries and service"
+	    echo -e "  uninstall --purge\tRemove binaries, service and vault (your passwords will be delete forever)"
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
- Security: Move Unix socket to XDG runtime dir with strict `0o600` permissions and add `peer_cred()` UID validation to prevent unauthorized access.
- Security: Introduce `--mlock` flag in `blackoutd` using `libc::mlockall` to prevent sensitive data from swapping to disk.
- Fix: Migrate vault storage path to XDG Base Directory (`~/.local/share/blackout`) resolving Systemd permission blocks.
- UI: Propagate mutable state (`&mut App`) to enable native ratatui scrolling and implement safe Option-based entry selection.
- Chore: Add `libc` and `tracing` dependencies, and ignore local debug logs.
- Chore: Setup.sh to install and uninstall blackout.